### PR TITLE
Add Flask backend server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # Brock
+
+## Database Example
+
+This repository includes a `weights_database.sql` script that defines a simple
+schema for storing datasets, models, layers, and weights used when training a
+neural network. Import it into your SQL server to experiment with managing your
+own neural-network data.
+
+## Backend Server
+
+A small Flask backend is provided in the `backend/` directory. Install
+requirements and run `backend/run.py` to start a REST API for interacting with
+these tables:
+
+```bash
+pip install -r requirements.txt
+python backend/run.py
+```
+
+The API exposes basic endpoints under `/api` for datasets, models, and training
+runs.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,15 @@
+from flask import Flask
+from .models import db
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object('backend.config.Config')
+    db.init_app(app)
+
+    with app.app_context():
+        db.create_all()
+
+    from .routes import bp as api_bp
+    app.register_blueprint(api_bp, url_prefix='/api')
+    return app

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,5 @@
+import os
+
+class Config:
+    SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URI', 'sqlite:///nn_weights.db')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,61 @@
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
+
+
+class Dataset(db.Model):
+    __tablename__ = 'datasets'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+    description = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, server_default=db.func.current_timestamp())
+
+
+class Sample(db.Model):
+    __tablename__ = 'samples'
+    id = db.Column(db.Integer, primary_key=True)
+    dataset_id = db.Column(db.Integer, db.ForeignKey('datasets.id'), nullable=False)
+    features = db.Column(db.LargeBinary)
+    label = db.Column(db.String(100))
+    dataset = db.relationship('Dataset', backref=db.backref('samples', lazy=True))
+
+
+class Model(db.Model):
+    __tablename__ = 'models'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+    description = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, server_default=db.func.current_timestamp())
+
+
+class Layer(db.Model):
+    __tablename__ = 'layers'
+    id = db.Column(db.Integer, primary_key=True)
+    model_id = db.Column(db.Integer, db.ForeignKey('models.id'), nullable=False)
+    layer_index = db.Column(db.Integer)
+    layer_type = db.Column(db.String(50))
+    parameters = db.Column(db.JSON)
+    model = db.relationship('Model', backref=db.backref('layers', lazy=True))
+
+
+class Weight(db.Model):
+    __tablename__ = 'weights'
+    id = db.Column(db.Integer, primary_key=True)
+    layer_id = db.Column(db.Integer, db.ForeignKey('layers.id'), nullable=False)
+    weight_data = db.Column(db.LargeBinary)
+    bias_data = db.Column(db.LargeBinary)
+    created_at = db.Column(db.DateTime, server_default=db.func.current_timestamp())
+    layer = db.relationship('Layer', backref=db.backref('weights', lazy=True))
+
+
+class TrainingRun(db.Model):
+    __tablename__ = 'training_runs'
+    id = db.Column(db.Integer, primary_key=True)
+    model_id = db.Column(db.Integer, db.ForeignKey('models.id'), nullable=False)
+    dataset_id = db.Column(db.Integer, db.ForeignKey('datasets.id'), nullable=False)
+    started_at = db.Column(db.DateTime, server_default=db.func.current_timestamp())
+    finished_at = db.Column(db.DateTime)
+    metrics = db.Column(db.JSON)
+    model = db.relationship('Model', backref=db.backref('training_runs', lazy=True))
+    dataset = db.relationship('Dataset', backref=db.backref('training_runs', lazy=True))

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1,0 +1,50 @@
+from flask import Blueprint, request, jsonify
+from .models import db, Dataset, Model, TrainingRun
+
+bp = Blueprint('api', __name__)
+
+
+@bp.route('/datasets', methods=['GET', 'POST'])
+def datasets_route():
+    if request.method == 'POST':
+        data = request.get_json() or {}
+        dataset = Dataset(name=data.get('name'), description=data.get('description'))
+        db.session.add(dataset)
+        db.session.commit()
+        return jsonify({'id': dataset.id, 'name': dataset.name}), 201
+    datasets = Dataset.query.all()
+    return jsonify([
+        {'id': d.id, 'name': d.name, 'description': d.description}
+        for d in datasets
+    ])
+
+
+@bp.route('/models', methods=['GET', 'POST'])
+def models_route():
+    if request.method == 'POST':
+        data = request.get_json() or {}
+        model = Model(name=data.get('name'), description=data.get('description'))
+        db.session.add(model)
+        db.session.commit()
+        return jsonify({'id': model.id, 'name': model.name}), 201
+    models = Model.query.all()
+    return jsonify([
+        {'id': m.id, 'name': m.name, 'description': m.description}
+        for m in models
+    ])
+
+
+@bp.route('/training_runs', methods=['GET'])
+def training_runs_route():
+    runs = TrainingRun.query.all()
+    return jsonify([
+        {
+            'id': r.id,
+            'model_id': r.model_id,
+            'dataset_id': r.dataset_id,
+            'started_at': r.started_at,
+            'finished_at': r.finished_at,
+            'metrics': r.metrics,
+        }
+        for r in runs
+    ])

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,0 +1,6 @@
+from backend import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-SQLAlchemy

--- a/weights_database.sql
+++ b/weights_database.sql
@@ -1,0 +1,63 @@
+-- SQL script to create a generic database for storing neural network
+-- datasets, models, and the associated weights.
+
+-- Create the database if it does not exist
+CREATE DATABASE IF NOT EXISTS nn_weights_db;
+USE nn_weights_db;
+
+-- Table of datasets used for training
+CREATE TABLE datasets (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Samples belonging to a dataset
+CREATE TABLE samples (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    dataset_id INT NOT NULL,
+    features BLOB,
+    label VARCHAR(100),
+    FOREIGN KEY (dataset_id) REFERENCES datasets(id)
+);
+
+-- Definition of a neural network model
+CREATE TABLE models (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Individual layers that compose a model
+CREATE TABLE layers (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    model_id INT NOT NULL,
+    layer_index INT,
+    layer_type VARCHAR(50),
+    parameters JSON,
+    FOREIGN KEY (model_id) REFERENCES models(id)
+);
+
+-- Weights associated with a layer
+CREATE TABLE weights (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    layer_id INT NOT NULL,
+    weight_data BLOB,
+    bias_data BLOB,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (layer_id) REFERENCES layers(id)
+);
+
+-- Training runs that produce weights for a model
+CREATE TABLE training_runs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    model_id INT NOT NULL,
+    dataset_id INT NOT NULL,
+    started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    finished_at TIMESTAMP NULL,
+    metrics JSON,
+    FOREIGN KEY (model_id) REFERENCES models(id),
+    FOREIGN KEY (dataset_id) REFERENCES datasets(id)
+);


### PR DESCRIPTION
## Summary
- add a minimal Flask backend under `backend/`
- expose REST API routes for datasets, models, and training runs
- document how to run the server in README
- add `requirements.txt` for dependencies

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68404476c7b0832ab038e8c0bea11cda